### PR TITLE
Fix: Someuser vs. You (mention) -- In English: the same. 

### DIFF
--- a/js/forum/dist/extension.js
+++ b/js/forum/dist/extension.js
@@ -455,7 +455,7 @@ System.register('flarum/mentions/addMentionedByList', ['flarum/extend', 'flarum/
               'span',
               { className: 'Post-mentionedBy-summary' },
               icon('reply'),
-              app.translator.transChoice('flarum-mentions.forum.post.mentioned_by' + (replies[0] === app.session.user ? '_self' : '') + '_text', names.length, {
+              app.translator.transChoice('flarum-mentions.forum.post.mentioned_by' + (replies[0].data.relationships.user.data.id === app.session.user.data.id ? '_self' : '') + '_text', names.length, {
                 count: names.length,
                 users: punctuateSeries(names)
               })

--- a/js/forum/dist/extension.js
+++ b/js/forum/dist/extension.js
@@ -455,7 +455,7 @@ System.register('flarum/mentions/addMentionedByList', ['flarum/extend', 'flarum/
               'span',
               { className: 'Post-mentionedBy-summary' },
               icon('reply'),
-              app.translator.transChoice('flarum-mentions.forum.post.mentioned_by' + (replies[0].data.relationships.user.data.id === app.session.user.data.id ? '_self' : '') + '_text', names.length, {
+              app.translator.transChoice('flarum-mentions.forum.post.mentioned_by' + (replies[0].user() === app.session.user ? '_self' : '') + '_text', names.length, {
                 count: names.length,
                 users: punctuateSeries(names)
               })

--- a/js/forum/src/addMentionedByList.js
+++ b/js/forum/src/addMentionedByList.js
@@ -116,7 +116,7 @@ export default function addMentionedByList() {
         <div className="Post-mentionedBy" config={config}>
           <span className="Post-mentionedBy-summary">
             {icon('reply')}
-            {app.translator.transChoice('flarum-mentions.forum.post.mentioned_by' + (replies[0].data.relationships.user.data.id === app.session.user.data.id ? '_self' : '') + '_text', names.length, {
+            {app.translator.transChoice('flarum-mentions.forum.post.mentioned_by' + (replies[0].user() === app.session.user ? '_self' : '') + '_text', names.length, {
               count: names.length,
               users: punctuateSeries(names)
             })}

--- a/js/forum/src/addMentionedByList.js
+++ b/js/forum/src/addMentionedByList.js
@@ -116,7 +116,7 @@ export default function addMentionedByList() {
         <div className="Post-mentionedBy" config={config}>
           <span className="Post-mentionedBy-summary">
             {icon('reply')}
-            {app.translator.transChoice('flarum-mentions.forum.post.mentioned_by' + (replies[0] === app.session.user ? '_self' : '') + '_text', names.length, {
+            {app.translator.transChoice('flarum-mentions.forum.post.mentioned_by' + (replies[0].data.relationships.user.data.id === app.session.user.data.id ? '_self' : '') + '_text', names.length, {
               count: names.length,
               users: punctuateSeries(names)
             })}


### PR DESCRIPTION
In Dutch: "Jij hebt" / "Someuser HEEFT" -> _self text was ignored, comparing POST with USER object.

Combines with [this pull request in Dutch translation](https://github.com/rodymol123/flarum-ext-dutch/pull/14)