### PR TITLE
Drop bower usage and go full npm

### DIFF
--- a/js/forum/Gulpfile.js
+++ b/js/forum/Gulpfile.js
@@ -5,6 +5,6 @@ gulp({
     'flarum/mentions': 'src/**/*.js'
   },
   files: [
-    'bower_components/textarea-caret-position/index.js'
+    'node_modules/textarea-caret/index.js'
   ]
 });

--- a/js/forum/bower.json
+++ b/js/forum/bower.json
@@ -1,6 +1,0 @@
-{
-  "name": "flarum-mentions",
-  "devDependencies": {
-    "textarea-caret-position": "~3.0.0"
-  }
-}

--- a/js/forum/package.json
+++ b/js/forum/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "gulp": "^3.9.1",
-    "flarum-gulp": "^0.2.0"
+    "flarum-gulp": "^0.2.0",
+    "textarea-caret": "~3.0.0"
   }
 }


### PR DESCRIPTION
Given the only bower dependency is also available in npm, I suggest we drop bower and require that package through npm.

This will reduce the number of commands required to setup the project as well as prevent errors like *not installing* the bower dependencies #25 

These changes have no impact on the resulting `extension.js`.